### PR TITLE
[HOTFIX] fixed application delete, create and department test

### DIFF
--- a/application-manager/src/main/java/ua/knu/knudev/applicationmanager/service/ApplicationService.java
+++ b/application-manager/src/main/java/ua/knu/knudev/applicationmanager/service/ApplicationService.java
@@ -65,7 +65,6 @@ public class ApplicationService implements ApplicationApi {
 
         department.setApplication(application);
 
-        departmentRepository.save(department);
         application = applicationRepository.save(application);
 
         return buildApplicationDto(application);

--- a/icc-integration-tests/src/test/java/ua/knu/knudev/integrationtests/DepartmentServiceIntegrationTest.java
+++ b/icc-integration-tests/src/test/java/ua/knu/knudev/integrationtests/DepartmentServiceIntegrationTest.java
@@ -84,6 +84,8 @@ public class DepartmentServiceIntegrationTest {
 
     public static final String TEST_DEPARTMENT_NAME_IN_ENGLISH = "test-department-name";
     public static final String TEST_DEPARTMENT_NAME_IN_UKRAINIAN = "тестове-ім'я-факультету";
+    public static final String NEW_TEST_DEPARTMENT_NAME_IN_ENGLISH = "test-department-name2";
+    public static final String NEW_TEST_DEPARTMENT_NAME_IN_UKRAINIAN = "тестове-ім'я-факультету2";
 
     private final List<String> uploadedAvatarFiles = new ArrayList<>();
     private final List<String> uploadedProblemPhotoFiles = new ArrayList<>();
@@ -245,11 +247,11 @@ public class DepartmentServiceIntegrationTest {
     @DisplayName("Should successfully create department when provided valid data")
     public void should_SuccessfullyCreateDepartment_When_ProvidedValidData() {
         DepartmentDto response = departmentService.create(new MultiLanguageFieldDto(
-                TEST_DEPARTMENT_NAME_IN_ENGLISH, TEST_DEPARTMENT_NAME_IN_UKRAINIAN));
+                NEW_TEST_DEPARTMENT_NAME_IN_ENGLISH, NEW_TEST_DEPARTMENT_NAME_IN_UKRAINIAN));
 
         assertNotNull(response);
-        assertEquals(testDepartment.getName().getEn(), response.name().getEn());
-        assertEquals(testDepartment.getName().getUk(), response.name().getUk());
+        assertEquals(NEW_TEST_DEPARTMENT_NAME_IN_ENGLISH, response.name().getEn());
+        assertEquals(NEW_TEST_DEPARTMENT_NAME_IN_UKRAINIAN, response.name().getUk());
     }
 
     @Test

--- a/icc-liquibase/src/main/resources/db/changelog/application_manager/2025_04_12_init_db.yaml
+++ b/icc-liquibase/src/main/resources/db/changelog/application_manager/2025_04_12_init_db.yaml
@@ -184,3 +184,4 @@ databaseChangeLog:
             referencedTableName: application
             referencedColumnNames: id
             constraintName: fk_department_applications_application
+            onDelete: CASCADE


### PR DESCRIPTION
- Fixed application delete by adding onDelete: CASCADE in liquibase. 
- Fixed duplicate application creation. 
- Fixed department test.